### PR TITLE
Implemented new version to persist new message 'Use a URL'

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ Upload.prototype = {
         '</div>' +
         '<hr>' +
         '<form class="skoll-upload-form" data-emit="skoll.upload.submit">' + 
-            '<p>Use a URL:</p>' + 
+            '<p>Use a URL: </p> ' + 
             '<input type="url" />' + 
             '<button class="skoll-button">Submit</button>' +
         '</form>' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skoll-upload",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The default upload plugin for Skoll",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is to  issue #1109. The message Use a URL is correct, but on the application is not showing correctly . 
